### PR TITLE
Rename to ragnarok/websocket

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ratchet/pawl",
+    "name": "ragnarok/websocket",
     "description": "Asynchronous WebSocket client",
     "keywords": [
         "WebSocket",
@@ -11,7 +11,7 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Ratchet\\Client\\": "src"
+            "Ragnarok\\Websocket\\": "src"
         },
         "files": [
             "src/functions_include.php"

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -1,6 +1,7 @@
 <?php
 
-namespace Ratchet\Client;
+namespace Ragnarok\Websocket;
+
 use Ratchet\RFC6455\Handshake\ClientNegotiator;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
@@ -136,7 +137,7 @@ class Connector {
 
         $uri = $uri->withScheme('wss' === $scheme ? 'HTTPS' : 'HTTP');
 
-        $headers += ['User-Agent' => 'Ratchet-Pawl/0.4.1'];
+        $headers += ['User-Agent' => 'Ragnarok-ws/0.4.1'];
 
         $request = array_reduce(array_keys($headers), function(RequestInterface $request, $header) use ($headers) {
             return $request->withHeader($header, $headers[$header]);

--- a/src/WebSocket.php
+++ b/src/WebSocket.php
@@ -1,5 +1,7 @@
 <?php
-namespace Ratchet\Client;
+
+namespace Ragnarok\Websocket;
+
 use Evenement\EventEmitterTrait;
 use Evenement\EventEmitterInterface;
 use React\Socket\ConnectionInterface;

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,5 +1,7 @@
 <?php
-namespace Ratchet\Client;
+
+namespace Ragnarok\Websocket;
+
 use React\EventLoop\LoopInterface;
 
 /**
@@ -7,7 +9,7 @@ use React\EventLoop\LoopInterface;
  * @param array              $subProtocols
  * @param array              $headers
  * @param LoopInterface|null $loop
- * @return \React\Promise\PromiseInterface<\Ratchet\Client\WebSocket>
+ * @return \React\Promise\PromiseInterface<\Ragnarok\Websocket\WebSocket>
  */
 function connect($url, array $subProtocols = [], $headers = [], LoopInterface $loop = null) {
     $connector = new Connector($loop);

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,5 +1,5 @@
 <?php
 
-if (!function_exists('Ratchet\Client\connect')) {
+if (!function_exists('Ragnarok\Websocket\connect')) {
     require __DIR__ . '/functions.php';
 }

--- a/tests/autobahn/runner.php
+++ b/tests/autobahn/runner.php
@@ -1,13 +1,14 @@
 <?php
-use Ratchet\Client\WebSocket;
+
+use Ragnarok\Websocket\WebSocket;
 use React\Promise\Deferred;
 
     require __DIR__ . '/../../vendor/autoload.php';
 
-    define('AGENT', 'Pawl/0.4');
+    define('AGENT', 'ragnarok-ws/0.4');
 
     $connFactory = function() {
-        $connector = new Ratchet\Client\Connector();
+        $connector = new \Ragnarok\Websocket\Connector();
 
         return function($url) use ($connector) {
             return $connector('ws://127.0.0.1:9001' . $url);

--- a/tests/unit/ConnectorTest.php
+++ b/tests/unit/ConnectorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use Ratchet\Client\Connector;
+use Ragnarok\Websocket\Connector;
 use React\EventLoop\Loop;
 use React\Promise\Promise;
 

--- a/tests/unit/RequestUriTest.php
+++ b/tests/unit/RequestUriTest.php
@@ -4,9 +4,7 @@
  */
 
 use PHPUnit\Framework\TestCase;
-use React\EventLoop\Factory;
-use Ratchet\Client\Connector;
-use Psr\Http\Message\RequestInterface;
+use Ragnarok\Websocket\Connector;
 
 class RequestUriTest extends TestCase {
     protected static function getPrivateClassMethod($className, $methodName) {
@@ -31,7 +29,7 @@ class RequestUriTest extends TestCase {
     function testGeneratedRequestUri($uri, $expectedRequestUri) {
         $connector = new Connector();
 
-        $generateRequest = self::getPrivateClassMethod('\Ratchet\Client\Connector', 'generateRequest');
+        $generateRequest = self::getPrivateClassMethod('\Ragnarok\Websocket\Connector', 'generateRequest');
         $request = $generateRequest->invokeArgs($connector, [$uri, [], []]);
 
         $this->assertEquals((string)$request->getUri(), $expectedRequestUri);


### PR DESCRIPTION
This repository is not intended to go back upstream to ratchet/pawl, thus should not use the same name/namespaces

API will change.
Upstream is unmaintained.